### PR TITLE
fix bug: MySQL server has gone away

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,14 +4,13 @@ languages:
 
 engines:
   duplication:
-    enabled: true
-    config:
-      languages:
-        - python
+    enabled: false
   fixme:
     enabled: true
   pep8:
     checks:
+      E501:
+        enabled: false
       W291:
         enabled: false
 

--- a/README.md
+++ b/README.md
@@ -106,10 +106,14 @@ make clean
 ```
 
 ## TODO
-* 前后端分离
-* 重构数据库访问方式
-* ~~缓存、失效机制~~
-* fix bug: `MySQL Server has gone away`
+
+- [ ] 前后端分离
+
+- [ ] 重构数据库访问方式
+
+- [x] 缓存、失效机制
+
+- [x] Fix Bug: `MySQL Server has gone away`. 详见此[MR](https://github.com/GuozhuHe/webspider/pull/4) 
 
 ## 其他常见问题
 有问题？联系我解决:

--- a/app/model/city.py
+++ b/app/model/city.py
@@ -20,7 +20,7 @@ class CityModel(BaseModel):
     def add(cls, id, name):
         city = cls(id=id, name=name)
         cls.session.merge(city)
-        cls.session.commit()
+        cls.session.flush()
 
     @classmethod
     def get(cls, id=None, name=None):

--- a/app/model/company.py
+++ b/app/model/company.py
@@ -32,7 +32,7 @@ class CompanyModel(BaseModel):
                       address=address, advantage=advantage, size=int(size))
         try:
             cls.session.merge(company)
-            cls.session.commit()
+            cls.session.flush()
         except InvalidRequestError as e:
             cls.session.rollback()
             raise e
@@ -51,7 +51,7 @@ class CompanyModel(BaseModel):
     @classmethod
     def update(cls, id, update_attr):
         cls.session.query(cls).filter_by(id=id).update(update_attr)
-        cls.session.commit()
+        cls.session.flush()
 
     @classmethod
     def count(cls, id=None):

--- a/app/model/company_industry.py
+++ b/app/model/company_industry.py
@@ -24,4 +24,4 @@ class CompanyIndustryModel(BaseModel):
     def add(cls, company_id, industry_id, city_id):
         company_industry = cls(company_id=int(company_id), industry_id=int(industry_id), city_id=int(city_id))
         cls.session.merge(company_industry)
-        cls.session.commit()
+        cls.session.flush()

--- a/app/model/industry.py
+++ b/app/model/industry.py
@@ -23,4 +23,4 @@ class IndustryModel(BaseModel):
     WHERE NOT EXISTS
     (SELECT id FROM industry WHERE name = :name)""")
         cls.session.execute(sql, {'name': name})
-        cls.session.commit()
+        cls.session.flush()

--- a/app/model/job.py
+++ b/app/model/job.py
@@ -34,7 +34,7 @@ class JobModel(BaseModel):
                   advantage=advantage, job_nature=int(job_nature), created_at=created_at)
         try:
             cls.session.merge(job)
-            cls.session.commit()
+            cls.session.flush()
         except InvalidRequestError as e:
             cls.session.rollback()
             raise e

--- a/app/model/job_keyword.py
+++ b/app/model/job_keyword.py
@@ -24,4 +24,4 @@ class JobKeywordModel(BaseModel):
     def add(cls, job_id, keyword_id, city_id):
         job_keyword = cls(job_id=int(job_id), keyword_id=int(keyword_id), city_id=int(city_id))
         cls.session.merge(job_keyword)
-        cls.session.commit()
+        cls.session.flush()

--- a/app/model/jobs_count.py
+++ b/app/model/jobs_count.py
@@ -24,7 +24,7 @@ class JobsCountModel(BaseModel):
                          guangzhou=int(guangzhou), shenzhen=int(shenzhen), shanghai=int(shanghai),
                          hangzhou=int(hangzhou), chengdu=int(chengdu))
         cls.session.merge(jobs_count)
-        cls.session.commit()
+        cls.session.flush()
 
     @classmethod
     def list(cls, keyword_id=None, start_time=None, end_time=None, order_key='date', sort_by='desc'):

--- a/app/model/keyword.py
+++ b/app/model/keyword.py
@@ -35,7 +35,7 @@ SELECT :name as name FROM dual
 WHERE NOT EXISTS
 (SELECT id FROM keyword WHERE name = :name)""")
         cls.session.execute(sql, {'name': name})
-        cls.session.commit()
+        cls.session.flush()
 
     @classmethod
     def get_most_frequently_keywords(cls, limit=10):

--- a/app/utils/util.py
+++ b/app/utils/util.py
@@ -72,7 +72,7 @@ def execute_sql_file(file_paths, db_session):
                 if sql_command.endswith(';'):
                     # Try to execute statemente and commit it
                     db_session.execute(text(sql_command))
-                    db_session.commit()
+                    db_session.flush()
                     sql_command = ''
 
 

--- a/common/db.py
+++ b/common/db.py
@@ -10,9 +10,9 @@ from common import config
 
 LOGGER = logging.getLogger(__name__)
 # isolation_level 读取没提交的数据 避免脏数据
-DB_engine = create_engine(config.DB_CONF['host'], isolation_level="READ UNCOMMITTED", pool_recycle=3600)
+DB_engine = create_engine(config.DB_CONF['host'], pool_recycle=3600)
 _BaseModel = declarative_base()
-_Session = sessionmaker(bind=DB_engine)
+_Session = sessionmaker(bind=DB_engine, autoflush=True, autocommit=True)
 
 
 class BaseModel(_BaseModel):
@@ -23,7 +23,7 @@ class BaseModel(_BaseModel):
         'mysql_charset': 'utf8mb4',
         'extend_existing': True,
     }
-    session = _Session(autocommit=False)
+    session = _Session()
 
 
 redis_pool = redis.ConnectionPool(host=config.REDIS_CONF['host'],


### PR DESCRIPTION
trace_back:
```~/app/webspider/env/lib/python3.6/site-packages/MySQLdb/cursors.py in _query(self, q)
    409
    410     def _query(self, q):
--> 411         rowcount = self._do_query(q)
    412         self._post_get_result()
    413         return rowcount

~/app/webspider/env/lib/python3.6/site-packages/MySQLdb/cursors.py in _do_query(self, q)
    372         db = self._get_db()
    373         self._last_executed = q
--> 374         db.query(q)
    375         self._do_get_result()
    376         return self.rowcount

~/app/webspider/env/lib/python3.6/site-packages/MySQLdb/connections.py in query(self, query)
    275             self.read_query_result()
    276         else:
--> 277             _mysql.connection.query(self, query)
    278
    279     def __enter__(self):

OperationalError: (_mysql_exceptions.OperationalError) (2006, 'MySQL server has gone away') [SQL: 'SELECT city.id AS city_id, city.name AS city_name \nFROM city \nWHERE city.id = %s'] [parameters: (3,)]
```

* 发现数据库的query会报出这样一个错误。且常在网站长时间无人访问后，进来一个访问时出现，这个错误的大概意思是客户端使用了一个无效的 MySQL 连接，猜测和数据库或者server的某种timeout设置有关。

* 进到数据库中，查询到各种timeout的值，对照 MySQL 的官方文档，发现很可能和`wait_timeout`有关，`wait_timeout`设置的是数据库连接闲置最大时间值，超过这个时间后 MySQL 服务器会丢弃该连接。此处为默认的8个小时，和出现`MySQL server has gone away`的时间点能对得上。
```
mysql> SHOW VARIABLES LIKE "%timeout%";
+-----------------------------+----------+
| Variable_name               | Value    |
+-----------------------------+----------+
| connect_timeout             | 10       |
| delayed_insert_timeout      | 300      |
| have_statement_timeout      | YES      |
| innodb_flush_log_at_timeout | 1        |
| innodb_lock_wait_timeout    | 50       |
| innodb_rollback_on_timeout  | OFF      |
| interactive_timeout         | 28800    |
| lock_wait_timeout           | 31536000 |
| net_read_timeout            | 30       |
| net_write_timeout           | 60       |
| rpl_stop_slave_timeout      | 31536000 |
| slave_net_timeout           | 60       |
| wait_timeout                | 28800    |
+-----------------------------+----------+
13 rows in set (0.00 sec)
```

* 所以可能就是Web服务由于超过8个小时无人访问，且保持数据库的连接所导致的，当长时间闲置后，进入一个请求，Web 服务使用了一个 MySQL 已经丢弃的无效连接，就会抛出异常了，此时应该在创建数据库连接时设置 `pool_recycle` 这个参数，只需要设置比 MySQL 的`wait_timeout`小，程序就会定时(`wait_timeout`)回收并重新设置 MySQL 连接。

* 还有一个重要的问题，就是因为使用了 `Sqlalchemy session`，该`session`会从当前的数据库连接池取一个连接使用，如果使用`session`后不主动把连接放回连接池，也会出现超时的情况，此时解决的方法有两个:

1. 不使用连接池: 这个方法最方便，但缺点就是不能使用连接池，每次与数据库交互时都得重新建立连接，十分耗时，代码如下:

``` python 
from sqlalchemy import create_engine
from sqlalchemy.pool import NullPool
# 在创建engine时指定pool为NullPool
engine = create_engine(config.DB_CONF['host'], pool_recycle=3600, pool=NullPool)
```
2. 使用`session`后把连接放回连接池:如`session.commit(), session.rollback()`，这种方法的优点就是可以和连接池配合使用，代码如下:

``` python
# 可以在创建session时指定autocommit=True
_Session = sessionmaker(bind=engine, autoflush=True, autocommit=True)

# 或者每次与数据库交互后手动commit
    def add(cls, id, name):
        city = cls(id=id, name=name)
        cls.session.add(city)
        cls.session.commit()

```