### PR TITLE
keywordctl 增加根据关键词名称获取关键词 id 的方法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ oj.py
 /webspider/security_constants.py
 celerybeat-schedule
 cove
+nohup.out

--- a/tests/test_controllers/test_keyword_ctl.py
+++ b/tests/test_controllers/test_keyword_ctl.py
@@ -12,6 +12,13 @@ class TestKeywordController(BaseTestCase):
         with self.assertRaises(ValueError):
             keyword_ctl.get_keyword_name_by_id(keyword_id=10001)
 
+    def test_get_keyword_id_by_name(self):
+        keyword_id = keyword_ctl.get_keyword_id_by_name(name='python')
+        self.assertEqual(keyword_id, 100)
+
+        with self.assertRaises(ValueError):
+            keyword_ctl.get_keyword_id_by_name(name='go')
+
     def test_insert_keyword_if_not_exist(self):
         keyword_name = 'C--'
         keyword_id = keyword_ctl.insert_keyword_if_not_exist(keyword_name)

--- a/webspider/controllers/keyword_ctl.py
+++ b/webspider/controllers/keyword_ctl.py
@@ -20,3 +20,10 @@ def get_keyword_name_by_id(keyword_id):
     if not keyword:
         raise ValueError('Get None when keyword id is {}'.format(keyword_id))
     return keyword.name
+
+
+def get_keyword_id_by_name(name):
+    keyword = KeywordModel.get_one(filter_by={'name': name})
+    if not keyword:
+        raise ValueError('Get None when keyword id is {}'.format(name))
+    return keyword.id

--- a/webspider/tasks/actor/lagou_data.py
+++ b/webspider/tasks/actor/lagou_data.py
@@ -23,12 +23,9 @@ def crawl_lagou_data_task():
 
     crawl_lagou_city_data_task.delay()
     # 目前只抓取这几个城市 全国:0, 北京:2 上海:3 杭州:6 深圳:215 广州:213 成都:252
-    # lagou_city_ids = [2, 3, 6, 215, 213, 252]
-    lagou_city_ids = [0]
-    # lagou_finance_stage_ids = [1, 2, 3, 4, 5, 6, 7, 8]
-    lagou_finance_stage_ids = [0]
-    # lagou_industry_ids = [24, 25, 33, 27, 29, 45, 31, 28, 47, 34, 35, 43, 32, 41, 26, 48, 38, 49, 10594]
-    lagou_industry_ids = [0]
+    lagou_city_ids = [2, 3, 6, 215, 213, 252]
+    lagou_finance_stage_ids = [1, 2, 3, 4, 5, 6, 7, 8]
+    lagou_industry_ids = [24, 25, 33, 27, 29, 45, 31, 28, 47, 34, 35, 43, 32, 41, 26, 48, 38, 49, 10594]
     # 爬取公司数据
     for industry_id in lagou_industry_ids:
         for city_id in lagou_city_ids:

--- a/webspider/tasks/celery_config.py
+++ b/webspider/tasks/celery_config.py
@@ -64,5 +64,5 @@ CELERY_ROUTES = {
                                                                    'routing_key': 'for_lagou_jobs_data'},
     'webspider.tasks.actor.lagou_jobs_count.*': {'exchange': 'lagou', 'routing_key': 'for_lagou_jobs_count'},
     'webspider.tasks.actor.lagou_data.*': {'exchange': 'lagou', 'routing_key': 'for_lagou_data'},
-    '*': {'exchange': 'default', 'routing_key': 'default'}
+    'webspider.tasks.actor.keyword_statistic.*': {'exchange': 'default', 'routing_key': 'default'}
 }


### PR DESCRIPTION
* 更改 `celery` 的一些配置
* 更改抓取职位的定时任务的城市，融资，行业限定。
* `keywordctl` 增加根据关键词名称获取关键词 id 的方法